### PR TITLE
Adopt `PhysicalConstants.jl` directly for defining necessary constants

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["cgarling <chris.t.garling@gmail.com>"]
 version = "0.1.3"
 
 [deps]
+PhysicalConstants = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ UnitfulAstro = "6112ee07-acf9-5e0f-b108-d242c714bf9f"
 UnitfulEquivalences = "da9c4bc3-91c8-4f02-8a40-6b990d2a7e0c"
 
 [compat]
+PhysicalConstants = "0.2"
 QuadGK = "0.1.1, 0.2, 0.3, 2"
 Roots = "1.4, 2"
 Unitful = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 1.0"

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,8 +1,11 @@
 module constants
 
-import Unitful as u
-import UnitfulAstro as ua
-import PhysicalConstants.CODATA2018 as PC
+import Unitful
+const u = Unitful
+import UnitfulAstro
+const ua = UnitfulAstro
+import PhysicalConstants#.CODATA2018 as PC
+const PC = PhysicalConstants.CODATA2018
 
 """ Newton's gravitational constant in units of kpc km^2 / Msun / s^2. """
 const G = PC.G |> ua.kpc * u.km^2 / ua.Msun / u.s^2 |> u.ustrip 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,15 +1,21 @@
 module constants
-# import Unitful as u
-# import UnitfulAstro as ua
+
+import Unitful as u
+import UnitfulAstro as ua
+import PhysicalConstants.CODATA2018 as PC
 
 """ Newton's gravitational constant in units of kpc km^2 / Msun / s^2. """
-const G = 4.30091727003628e-6 # Gravitational constant in kpc * km^2 / Msun / s^2, CODATA2018
+const G = PC.G |> ua.kpc * u.km^2 / ua.Msun / u.s^2 |> u.ustrip 
+# const G = 4.30091727003628e-6
 """ Newton's gravitational constant in units of cm^3 / g / s^2. """
-const G_CGS = 6.6743e-8 # Gravitational constant in cm^3 / g / s^2, CODATA2018
+const G_CGS = PC.G |> u.cm^3 / u.g / u.s^2 |> u.ustrip
+# const G_CGS = 6.6743e-8 
 """ Number of centimeters in a kiloparsec. """
-const KPC_CM = 3.0856775814913673e21 # kiloparsec in cm, CODATA2018
+const KPC_CM = 1 * ua.kpc |> u.cm |> u.ustrip
+# const KPC_CM = 3.0856775814913673e21
 """ Number of kilometers in a kiloparsec. """
-const KPC_KM = 3.0856775814913673e16 # kiloparsec in km, CODATA2018
+const KPC_KM = 1 * ua.kpc |> u.km |> u.ustrip
+# const KPC_KM = 3.0856775814913673e16
 """ Linear overdensity threshold for halo collapse for the spherical top-hat collapse model, ``3/5 \\times (3π/2)^{2/3}``. """
 const DELTA_COLLAPSE = 1.686470199841145 # linear overdensity threshold for halo collapse for the spherical top-hat collapse model, 3/5*(3π/2)^(2/3)
 """ Prefactor for the critical density of the Universe, in units of g / cm^3,
@@ -17,19 +23,22 @@ const DELTA_COLLAPSE = 1.686470199841145 # linear overdensity threshold for halo
 \\frac{3}{8πG} \\ \\left(100 \\ \\text{km} \\ \\text{s}^{-1} \\ \\text{Mpc}^{-1} \\right)^2
 ```
 """
-const RHO_C_Z0_CGS = 1.878341616932337e-29 # * u.g / u.cm^3 # critical density at z=0 in gram / cm^3
+const RHO_C_Z0_CGS = 3/(8π * PC.G) * (100 * u.km / u.s / ua.Mpc)^2 |> u.g / u.cm^3 |> u.ustrip
+# const RHO_C_Z0_CGS = 1.878341616932337e-29
 """ Prefactor for the critical density of the Universe, in units of Msun / kpc^3,
 ```math
 \\frac{3}{8πG} \\ \\left(100 \\ \\text{km} \\ \\text{s}^{-1} \\ \\text{Mpc}^{-1} \\right)^2
 ```
 """
-const RHO_C_Z0_KPC = 2.77536627245708E2 # * ua.Msun / ua.kpc^3# critical density at z=0 in Msun / kpc^3
+const RHO_C_Z0_KPC = 3/(8π * PC.G) * (100 * u.km / u.s / ua.Mpc)^2 |> ua.Msun / ua.kpc^3 |> u.ustrip
+# const RHO_C_Z0_KPC = 2.77536627245708E2
 """ Prefactor for the critical density of the Universe, in units of Msun / Mpc^3,
 ```math
 \\frac{3}{8πG} \\ \\left(100 \\ \\text{km} \\ \\text{s}^{-1} \\ \\text{Mpc}^{-1} \\right)^2
 ```
 """
-const RHO_C_Z0_MPC = 2.7753662724570807e11 # * ua.Msun / ua.kpc^3# critical density at z=0 in Msun / Mpc^3
+const RHO_C_Z0_MPC = 3/(8π * PC.G) * (100 * u.km / u.s / ua.Mpc)^2 |> ua.Msun / ua.Mpc^3 |> u.ustrip
+# const RHO_C_Z0_MPC = 2.7753662724570807e11
 """ Conversion factor between CMB temperature and neutrino temperature, `` \\frac{4}{11}^{1/3}``. """
 const TNU_PREFAC = 0.7137658555036082 # Equivalent to (4//11)^(1/3); for neutrino temperature
 # const TNU_PREFAC = big"0.7137658555036081706718999917626612475907965475890380669156267520845831470677149" # Equivalent to (4//11)^(1/3); for neutrino temperature


### PR DESCRIPTION
The values of the constants are unchanged and do not cause us to fail any tests here or in downstream packages. However, downstream I have found cause to use `PhysicalConstants.jl` and so, to enforce consistency, I figure I should be using it throughout the package stack. 